### PR TITLE
fix(explore): commit manual-points build deps so main compiles

### DIFF
--- a/composables/use-user-route-points.ts
+++ b/composables/use-user-route-points.ts
@@ -1,0 +1,122 @@
+import { nanoid } from "nanoid";
+
+import type { ExploreAnchorPoint, ExploreCandidatePlace } from "~/lib/explore/context";
+import type { RouteMapPoint } from "~/lib/explore/route-map";
+import type { SelectedExploreCity } from "~/lib/explore/search";
+
+export type UserRoutePoint = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  day: number;
+};
+
+// Module-level state so the map page, the placement control, and the Mapbox
+// click handler all read and mutate the same list of manually dropped stops.
+const userPoints = ref<UserRoutePoint[]>([]);
+const isAddMode = ref(false);
+
+function addUserPoint(input: { lat: number; lng: number; day: number; name?: string }) {
+  const id = nanoid(8);
+  const name = input.name?.trim() || `Моя точка ${userPoints.value.length + 1}`;
+
+  userPoints.value = [
+    ...userPoints.value,
+    { id, name, lat: input.lat, lng: input.lng, day: input.day },
+  ];
+
+  return id;
+}
+
+function removeUserPoint(id: string) {
+  userPoints.value = userPoints.value.filter(point => point.id !== id);
+}
+
+function clearUserPoints() {
+  userPoints.value = [];
+}
+
+function setAddMode(enabled: boolean) {
+  isAddMode.value = enabled;
+}
+
+function toggleAddMode() {
+  isAddMode.value = !isAddMode.value;
+}
+
+function toUserRouteMapPoint(point: UserRoutePoint, index = 0): RouteMapPoint {
+  return {
+    id: `user-place-${point.id}`,
+    sourceId: point.id,
+    markerKind: "user-place",
+    sequence: index,
+    day: point.day,
+    name: point.name,
+    lat: point.lat,
+    lng: point.lng,
+  };
+}
+
+// Shapes a manual stop as a selected candidate place so the AI route generator
+// treats it as a place to weave into the route.
+function toExploreCandidatePlace(point: UserRoutePoint): ExploreCandidatePlace {
+  return {
+    id: `user-place-${point.id}`,
+    name: point.name,
+    coordinates: { lat: point.lat, long: point.lng },
+    categories: [],
+    source: "fallback",
+    selected: true,
+  };
+}
+
+// Shapes a manual stop as an anchor point: the AI must route through it and then
+// enrich the path with additional on-the-way places, instead of merely treating
+// it as one more optional candidate.
+function toAnchorPoint(point: UserRoutePoint): ExploreAnchorPoint {
+  return {
+    id: point.id,
+    name: point.name,
+    coordinates: { lat: point.lat, long: point.lng },
+    day: point.day,
+  };
+}
+
+// Synthesises a region anchor from the centroid of the placed points so the AI
+// can generate a route from them even when no city has been chosen.
+function buildAnchorCity(): SelectedExploreCity | null {
+  const points = userPoints.value;
+  if (!points.length)
+    return null;
+
+  const lat = points.reduce((total, point) => total + point.lat, 0) / points.length;
+  const long = points.reduce((total, point) => total + point.lng, 0) / points.length;
+  const id = `manual-${lat.toFixed(4)}-${long.toFixed(4)}`;
+
+  return {
+    id,
+    provider: "nominatim",
+    providerId: id,
+    label: "Мои точки",
+    name: "Мои точки",
+    coordinates: { lat, long },
+    source: "fallback",
+  };
+}
+
+export function useUserRoutePoints() {
+  return {
+    userPoints,
+    isAddMode,
+    addUserPoint,
+    removeUserPoint,
+    clearUserPoints,
+    setAddMode,
+    toggleAddMode,
+    toUserRouteMapPoint,
+    toExploreCandidatePlace,
+    toAnchorPoint,
+    buildAnchorCity,
+  };
+}

--- a/lib/explore/route-map.ts
+++ b/lib/explore/route-map.ts
@@ -138,6 +138,79 @@ export function formatRouteDistance(meters: number | null | undefined): string |
   return `${kilometers.toFixed(kilometers >= 10 ? 0 : 1)} km`;
 }
 
+const EARTH_RADIUS_METERS = 6371000;
+
+type LngLatLike = {
+  lat: number;
+  lng: number;
+};
+
+export function haversineDistanceMeters(from: LngLatLike, to: LngLatLike): number {
+  const toRadians = (value: number) => (value * Math.PI) / 180;
+  const deltaLat = toRadians(to.lat - from.lat);
+  const deltaLng = toRadians(to.lng - from.lng);
+  const fromLat = toRadians(from.lat);
+  const toLat = toRadians(to.lat);
+
+  const a = Math.sin(deltaLat / 2) ** 2
+    + Math.sin(deltaLng / 2) ** 2 * Math.cos(fromLat) * Math.cos(toLat);
+
+  return 2 * EARTH_RADIUS_METERS * Math.asin(Math.min(1, Math.sqrt(a)));
+}
+
+// Returns the index at which `candidate` should be spliced into `points` so the
+// total path grows as little as possible — the classic cheapest-insertion
+// heuristic. This keeps a manually dropped stop "on the way" instead of forcing
+// a long detour.
+export function findCheapestInsertionIndex(points: LngLatLike[], candidate: LngLatLike): number {
+  if (points.length === 0)
+    return 0;
+  if (points.length === 1)
+    return 1;
+
+  // Seed with the two endpoints: append after the last stop or prepend before
+  // the first one.
+  let bestIndex = points.length;
+  let bestCost = haversineDistanceMeters(points[points.length - 1], candidate);
+
+  const prependCost = haversineDistanceMeters(candidate, points[0]);
+  if (prependCost < bestCost) {
+    bestIndex = 0;
+    bestCost = prependCost;
+  }
+
+  for (let i = 1; i < points.length; i += 1) {
+    const previous = points[i - 1];
+    const next = points[i];
+    const detour = haversineDistanceMeters(previous, candidate)
+      + haversineDistanceMeters(candidate, next)
+      - haversineDistanceMeters(previous, next);
+
+    if (detour < bestCost) {
+      bestIndex = i;
+      bestCost = detour;
+    }
+  }
+
+  return bestIndex;
+}
+
+// Weaves user-dropped points into a base route one at a time, each at its
+// cheapest slot, then renumbers the combined sequence.
+export function foldUserPointsIntoRoute(
+  basePoints: RouteMapPoint[],
+  userPoints: RouteMapPoint[],
+): RouteMapPoint[] {
+  let combined = [...basePoints];
+
+  for (const userPoint of userPoints) {
+    const index = findCheapestInsertionIndex(combined, userPoint);
+    combined = [...combined.slice(0, index), userPoint, ...combined.slice(index)];
+  }
+
+  return combined.map((point, index) => ({ ...point, sequence: index }));
+}
+
 function normalizeRouteMapPoints(points: RoutePoint[] | RouteMapPoint[]): RouteMapPoint[] {
   if (points.length === 0)
     return [];


### PR DESCRIPTION
## Проблема
После мёржа PR #5 прод-сборка Vercel падала:
`"foldUserPointsIntoRoute" is not exported by "lib/explore/route-map.ts"`.

Фича manual-points была закоммичена по частям: `pages/explore.vue` импортит `findCheapestInsertionIndex`/`foldUserPointsIntoRoute` из `route-map.ts` и вызывает `useUserRoutePoints()`, но эти экспорты были незакоммичены, а `composables/use-user-route-points.ts` — untracked. `main` не собирался.

## Фикс
Коммит недостающих зависимостей (2 файла):
- `lib/explore/route-map.ts` — добавлены экспорты `findCheapestInsertionIndex`, `foldUserPointsIntoRoute`
- `composables/use-user-route-points.ts` — добавлен composable

Локальная сборка в чистом worktree прошла стадию client-build (где была ошибка); финальный OOM — локальный артефакт Windows (флаг `--max-old-space-size=8192` не применяется в Windows-шелле), на Vercel/Linux неактуален.