### PR TITLE
ci: pass all required env vars to the lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -53,4 +53,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install
+      # `@nuxt/eslint` writes .nuxt/eslint.config.mjs (imported by eslint.config.mjs)
+      # during module setup. The postinstall `nuxt prepare` does not persist it in
+      # CI, so run prepare explicitly here to guarantee the flat config exists.
+      - run: pnpm exec nuxi prepare
       - run: pnpm lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,8 +14,30 @@ jobs:
 
     env:
       NODE_ENV: development
+      # `pnpm install` runs `postinstall: nuxt prepare`, which imports
+      # nuxt.config.ts -> lib/env.ts and validates the full env schema. This job
+      # only installs + lints (it never uses these values), but every required
+      # var must be defined or the schema throws "Missing required values".
+      # `z.string()` accepts "", so absent secrets resolve harmlessly to empty;
+      # real values flow through automatically once set in the `build` environment.
       TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
       TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+      BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+      BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL }}
+      AUTH_GITHUB_CLIENT_ID: ${{ secrets.AUTH_GITHUB_CLIENT_ID }}
+      AUTH_GITHUB_CLIENT_SECRET: ${{ secrets.AUTH_GITHUB_CLIENT_SECRET }}
+      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+      S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+      S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+      S3_REGION: ${{ secrets.S3_REGION }}
+      S3_BUCKET: ${{ secrets.S3_BUCKET }}
+      S3_BUCKET_URL: ${{ secrets.S3_BUCKET_URL }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+      YANDEX_MAPS_API_KEY: ${{ secrets.YANDEX_MAPS_API_KEY }}
+      GOOGLE_PLACES_API_KEY: ${{ secrets.GOOGLE_PLACES_API_KEY }}
 
     strategy:
       matrix:


### PR DESCRIPTION
## Проблема
GitHub Actions job `build` падал на `pnpm install`: `postinstall: nuxt prepare` импортит `nuxt.config.ts → lib/env.ts` и валидирует всю схему env, а воркфлоу отдавал только `TURSO_*`. Отсюда `Missing required values in .env` по 16 обязательным переменным.

## Фикс
Домаплены все 16 обязательных переменных в `env:`-блоке из окружения `build`. Job их не использует (только install + lint), а `z.string()` принимает `""`, поэтому чек зелёный независимо от того, заданы секреты или нет; реальные значения подхватятся автоматически, если их добавить.

Чисто инфраструктурная правка, кода приложения не касается.